### PR TITLE
Prepare for 0.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+ -  0.1.1 (2020-02-24)
+     * Upgrade terraform to 0.12.20
+
  -  0.1.0 (2020-01-23)
      *  Bump regula to v0.1.0.
      *  Improve examples and README.md.

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN mkdir /tmp/terraform-aws && \
     rm -rf /tmp/terraform-aws
 
 # Install regula script and libraries.
-ARG REGULA_VERSION=v0.1.1
+ARG REGULA_VERSION=v0.1.0
 RUN mkdir -p /opt/regula && \
     curl -L "https://github.com/fugue/regula/archive/${REGULA_VERSION}.tar.gz" | \
         tar -xz --strip-components=1 -C /opt/regula/

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN mkdir /tmp/terraform-aws && \
     rm -rf /tmp/terraform-aws
 
 # Install regula script and libraries.
-ARG REGULA_VERSION=v0.1.0
+ARG REGULA_VERSION=v0.1.1
 RUN mkdir -p /opt/regula && \
     curl -L "https://github.com/fugue/regula/archive/${REGULA_VERSION}.tar.gz" | \
         tar -xz --strip-components=1 -C /opt/regula/

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@master
     - name: Regula
       id: regula
-      uses: fugue/regula-action@v0.1.0
+      uses: fugue/regula-action@v0.1.1
       with:
         terraform_directory: .
         rego_paths: /opt/regula/rules


### PR DESCRIPTION
This PR captures the documentation and examples to use terraform 0.12.20. Existing statefiles created with 0.12.20 don't work with 0.12.18. This is something to think about going forward.