### PR TITLE
Update README - example workflow, inputs, CloudFormation references

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Example
 
-Here's an example workflow file:
+Here's an example workflow file.  It checks three different IaC configurations: one Terraform directory and two CloudFormation templates:
 
 ```yaml
 on: [push]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # regula-action
 
-[Regula] is a tool that evaluates Terraform infrastructure-as-code for potential security misconfigurations and compliance violations prior to deployment. This is a [GitHub Action] to run [Regula] against your repository.
+[Regula] is a tool that evaluates CloudFormation and Terraform infrastructure-as-code for potential AWS, Azure, and Google Cloud security misconfigurations and compliance violations prior to deployment. This is a [GitHub Action] to run [Regula] against your repository.
 
 ## Example
 
@@ -8,21 +8,40 @@ Here's an example workflow file:
 
 ```yaml
 on: [push]
+
 jobs:
-  regula_job:
+  regula_tf_job:
     runs-on: ubuntu-latest
-    name: Regula
+    name: Regula Terraform
     steps:
     - uses: actions/checkout@master
-    - name: Regula
-      id: regula
-      uses: fugue/regula-action@v0.5.0
+    - uses: fugue/regula-action@3a08390a6355f9938b752100ca43dec0b5b0c5b6
       with:
-        terraform_directory: .
-        rego_paths: /opt/regula/rules
+        input_path: infra_tf
+        rego_paths: /opt/regula/rules example_custom_rule
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+  regula_cfn_job:
+    runs-on: ubuntu-latest
+    name: Regula CloudFormation
+    steps:
+    - uses: actions/checkout@master
+    - uses: fugue/regula-action@3a08390a6355f9938b752100ca43dec0b5b0c5b6
+      with:
+        input_path: infra_cfn/cloudformation.yaml
+        rego_paths: /opt/regula/rules
+
+  regula_valid_cfn_job:
+    runs-on: ubuntu-latest
+    name: Regula Valid CloudFormation
+    steps:
+    - uses: actions/checkout@master
+    - uses: fugue/regula-action@3a08390a6355f9938b752100ca43dec0b5b0c5b6
+      with:
+        input_path: infra_valid_cfn/cloudformation.yaml
+        rego_paths: /opt/regula/rules
 ```
 
 You can see this example in action in the
@@ -30,22 +49,26 @@ You can see this example in action in the
 
 ## Inputs
 
--   `terraform_directory`: the directory where your terraform files are located.
-    This defaults to `.`.
+-   `input_path`: Either a Terraform project directory, Terraform JSON plan, or a CloudFormation template.
+    This defaults to `.` (the root of your repository).
 -   `rego_paths`: all paths that need to be passed to OPA.  This is typically
     `/opt/regula/rules`, which contains some default Regula rules, but you can
     also pass paths within your repository for custom checks.
 
+Note: `terraform_directory` is deprecated. Use `input_path` instead.
+
 ## Environment variables
 
-Because Regula runs `terraform init`, `AWS_ACCESS_KEY_ID` and
+**Terraform:** Because Regula runs `terraform init`, `AWS_ACCESS_KEY_ID` and
 `AWS_SECRET_ACCESS_KEY` must be set. Your AWS account will not be modified, but
 if you want to be absolutely certain about this you can always create a dummy
 user within your account.
+
+**CloudFormation:** No keys are necessary to evaluate CloudFormation.
 
 [GitHub Action]: https://github.com/features/actions
 [Regula]: https://github.com/fugue/regula
 
 ## How to use this GitHub Action
 
-To use [Regula] to evaluate the Terraform in your own repository via GitHub Actions, see the instructions in [regula-ci-example](https://github.com/fugue/regula-ci-example). The example walks through how to use this GitHub Action in your own repo.
+To use [Regula] to evaluate the infrastructure-as-code in your own repository via GitHub Actions, see the instructions in [regula-ci-example](https://github.com/fugue/regula-ci-example). The example walks through how to use this GitHub Action in your own repo.


### PR DESCRIPTION
Updated the README to:

- Use the new example workflow from [regula-ci-example](https://github.com/fugue/regula-ci-example/)
- Change `terraform_directory` to `input_path`
- Add references to CloudFormation