### PR TITLE
Support specifying the output format

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -48,6 +48,19 @@ inputs:
         off
     required: false
     default: unknown
+  output_format:
+    description: |
+      Set the output format. Defaults to json.
+      Possible values are:
+        text -- A human friendly format (default)
+        json -- A JSON report containing rule results and a summary
+        table -- An ASCII table of rule results
+        junit -- The JUnit XML format
+        tap -- The Test Anything Protocol format
+        compact -- An alternate, more compact human friendly format
+        none -- Do not print any output on stdout
+    required: false
+    default: json
 outputs:
   rules_passed:
     description: 'Number of passed rules'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,13 +33,20 @@ if [[ -v INPUT_INPUT_TYPE && -n "${INPUT_INPUT_TYPE}" ]]; then
   REGULA_OPTS+=("-t" "${INPUT_INPUT_TYPE}")
 fi
 
+if [[ -v INPUT_OUTPUT_FORMAT && -n "${INPUT_OUTPUT_FORMAT}" ]]; then
+  REGULA_OPTS+=("-f" "${INPUT_OUTPUT_FORMAT}")
+fi
+
 EXIT_CODE=0
-REGULA_OUTPUT=$(cd "$GITHUB_WORKSPACE" && regula run -f json ${REGULA_OPTS[@]} $INPUT_PATH) ||
+REGULA_OUTPUT=$(cd "$GITHUB_WORKSPACE" && regula run ${REGULA_OPTS[@]} $INPUT_PATH) ||
   EXIT_CODE=$?
 echo "${REGULA_OUTPUT}"
 
-RULES_PASSED="$(jq -r '.summary.rule_results.PASS' <<<"$REGULA_OUTPUT")"
-RULES_FAILED="$(jq -r '.summary.rule_results.FAIL' <<<"$REGULA_OUTPUT")"
-echo "::set-output name=rules_passed::$RULES_PASSED"
-echo "::set-output name=rules_failed::$RULES_FAILED"
+if [[ -v INPUT_OUTPUT_FORMAT && "${INPUT_OUTPUT_FORMAT}" == "json" ]]; then
+  RULES_PASSED="$(jq -r '.summary.rule_results.PASS' <<<"$REGULA_OUTPUT")"
+  RULES_FAILED="$(jq -r '.summary.rule_results.FAIL' <<<"$REGULA_OUTPUT")"
+  echo "::set-output name=rules_passed::$RULES_PASSED"
+  echo "::set-output name=rules_failed::$RULES_FAILED"
+fi
+
 exit ${EXIT_CODE}


### PR DESCRIPTION
Adds the ability to change output format by passing in `output_format: text`

Example usage:

```yaml
      - uses: thomasv314/regula-action@support-output-format
        with:
          output_format: text
          input_path: test-manifest.yaml
          input_type: k8s
          user_only: true
          rego_paths: test/chart
```