### PR TITLE
Remove USER from dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM fugue/regula:v2.6.1 AS regula
 USER root
 RUN apk add --update bash jq
-USER ${APP_USER}
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
The USER instruction is not supported in GitHub Actions: https://docs.github.com/en/actions/creating-actions/dockerfile-support-for-github-actions#user

All commands must run as root, or rules cannot be downloaded.